### PR TITLE
Add fatahchan.is-a.dev for Vercel

### DIFF
--- a/domains/fatahchan.json
+++ b/domains/fatahchan.json
@@ -1,6 +1,7 @@
 {
   "owner": {
-    "username": "fatahchan"
+    "username": "fatahchan",
+    "email": "fatah@example.com"
   },
   "records": {
     "CNAME": "cname.vercel-dns.com"


### PR DESCRIPTION
# Requirements
- [x] I have **read** and **agreed** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] My website is not for commercial use.
- [x] I have provided sufficient contact information in the  key.
- [x] I have provided a preview of my website below.

# Website Preview
[My Portfolio](https://fatahchan-portfolio.vercel.app/)

---
This PR adds the fatahchan.is-a.dev domain pointing to Vercel.

- Added fatahchan.json with CNAME record for Vercel
- Added _vercel.fatahchan.json for domain verification
- Updated contact information in owner field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Owner contact email is now included for the Fatahchan domain, appearing wherever owner details are shown (e.g., domain details, listings).
  * Enables direct email communication with the owner for inquiries and support.
  * Improves attribution and notification targeting tied to owner information.
  * Additive change with no impact on existing behaviors or layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->